### PR TITLE
Fixed bug in StrEnumMeta due to changes introduced in Python 3.8.

### DIFF
--- a/aiopolly/__init__.py
+++ b/aiopolly/__init__.py
@@ -12,5 +12,5 @@ __all__ = [
     'utils'
 ]
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __api_date__ = datetime.date(2019, 7, 30)  # July 30, 2019

--- a/aiopolly/utils/strenum.py
+++ b/aiopolly/utils/strenum.py
@@ -101,7 +101,7 @@ class StrEnumMeta(EnumMeta):
 
     def __new__(mcs, cls, bases, class_dict, sep: AnyStr = None, converter: Callable[[str], str] = None):
         # In Python 3.8 the signature of 'EnumMeta._get_mixins_' was changed from (bases) to (class_name, bases)
-        if len(signature(mcs._get_mixins_).parameters) == 2:  # (class_name, bases)
+        if sys.version_info >= (3, 8):  # (class_name, bases)
             mixin_type, base_enum = mcs._get_mixins_(cls, bases)
         else:  # Fallback to (bases) signature
             mixin_type, base_enum = mcs._get_mixins_(bases)

--- a/aiopolly/utils/strenum.py
+++ b/aiopolly/utils/strenum.py
@@ -2,8 +2,8 @@
 Based on: https://github.com/MrMrRobat/AnyStrEnum
 """
 
+import sys
 from enum import Enum, EnumMeta, _EnumDict, auto
-from inspect import signature
 from types import FunctionType
 from typing import List, Callable, AnyStr, Set, TypeVar, Type, Any
 

--- a/aiopolly/utils/strenum.py
+++ b/aiopolly/utils/strenum.py
@@ -101,8 +101,6 @@ class StrEnumMeta(EnumMeta):
 
     def __new__(mcs, cls, bases, class_dict, sep: AnyStr = None, converter: Callable[[str], str] = None):
         # In Python 3.8 the signature of 'EnumMeta._get_mixins_' was changed from (bases) to (class_name, bases)
-        # However, 'class_name' is unneccessary and only used to print an exception
-        # So we examine the signature accordingly and pick the right one
         if len(signature(mcs._get_mixins_).parameters) == 2:  # (class_name, bases)
             mixin_type, base_enum = mcs._get_mixins_(cls, bases)
         else:  # Fallback to (bases) signature

--- a/aiopolly/utils/strenum.py
+++ b/aiopolly/utils/strenum.py
@@ -3,6 +3,7 @@ Based on: https://github.com/MrMrRobat/AnyStrEnum
 """
 
 from enum import Enum, EnumMeta, _EnumDict, auto
+from inspect import signature
 from types import FunctionType
 from typing import List, Callable, AnyStr, Set, TypeVar, Type, Any
 
@@ -99,7 +100,13 @@ class StrEnumMeta(EnumMeta):
         return super().__prepare__(*args, **kwargs)
 
     def __new__(mcs, cls, bases, class_dict, sep: AnyStr = None, converter: Callable[[str], str] = None):
-        mixin_type, base_enum = mcs._get_mixins_(bases)
+        # In Python 3.8 the signature of 'EnumMeta._get_mixins_' was changed from (bases) to (class_name, bases)
+        # However, 'class_name' is unneccessary and only used to print an exception
+        # So we examine the signature accordingly and pick the right one
+        if len(signature(mcs._get_mixins_).parameters) == 2:  # (class_name, bases)
+            mixin_type, base_enum = mcs._get_mixins_('StrEnumMeta', bases)
+        else:  # Fallback to (bases) signature
+            mixin_type, base_enum = mcs._get_mixins_(bases)
         if not issubclass(base_enum, BaseStrEnum):
             raise TypeError(f'Unexpected Enum type \'{base_enum.__name__}\'. '
                             f'Only {BaseStrEnum.__name__} and its subclasses are allowed')

--- a/aiopolly/utils/strenum.py
+++ b/aiopolly/utils/strenum.py
@@ -104,7 +104,7 @@ class StrEnumMeta(EnumMeta):
         # However, 'class_name' is unneccessary and only used to print an exception
         # So we examine the signature accordingly and pick the right one
         if len(signature(mcs._get_mixins_).parameters) == 2:  # (class_name, bases)
-            mixin_type, base_enum = mcs._get_mixins_('StrEnumMeta', bases)
+            mixin_type, base_enum = mcs._get_mixins_(cls, bases)
         else:  # Fallback to (bases) signature
             mixin_type, base_enum = mcs._get_mixins_(bases)
         if not issubclass(base_enum, BaseStrEnum):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7  ',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ],
 )


### PR DESCRIPTION
Apparently Python3.8 onwards changed the implementation of `EnumMeta._get_mixins`, which broke `StrEnum`.
The only change though was to add an additional `class_name` parameter that only gets used if an exception is raised.
So, I added code to inspect the signature to make it work on both <3.8 and >=3.8.
Tested on both 3.7 and 3.8

Also, if you could, could you push this to PyPI if you accept the PR? I usually have to install the package directly from my fork in my deployments which is a tiny bit annoying.

Thanks!